### PR TITLE
Retain align if configured

### DIFF
--- a/src/pavemat.typ
+++ b/src/pavemat.typ
@@ -219,7 +219,7 @@
     let row-gap = ma.fields().at("row-gap", default: math.mat.row-gap) / 2
     let col-gap = ma.fields().at("column-gap", default: math.mat.column-gap) / 2
 
-    let mat-grid = grid(columns: m, align: center + horizon, inset: (x: col-gap, y: row-gap), ..cells, ..dashes)
+    let mat-grid = grid(columns: m, align: ma.fields().at("align", default: math.mat.align), inset: (x: col-gap, y: row-gap), ..cells, ..dashes)
 
     let is-block = if block == auto {
       eq.fields().at("block", default: math.equation.block)


### PR DESCRIPTION
After playing around a bit with this library, I noticed that all configuration regarding the [`align` parameter](https://typst.app/docs/reference/math/mat/#parameters-align) of matrices is ignored. The root cause of this is that, currently, during the "re-rendering" of matrices as grids, the library statically enforces an alignment of `center+horizon`. As a remedy to this, switched it to either retain the locally configured `align` parameter or, if not configured, default to the global default.